### PR TITLE
Bug fixes: BCI-IV-2A naming, SHU stats, and split I/O cleanup

### DIFF
--- a/preprocessing/BCI-IV-2A/data_process.py
+++ b/preprocessing/BCI-IV-2A/data_process.py
@@ -8,8 +8,8 @@ import sys
 
 data_root = sys.argv[1]  
 print(f"Data root: {data_root}")
-raw_data_path = os.path.join(data_root,'BCI-4-2A/raw_data')
-processed_data_path = os.path.join(data_root,'BCI-4-2A/processed_data')
+raw_data_path = os.path.join(data_root,'BCI-IV-2A/raw_data')
+processed_data_path = os.path.join(data_root,'BCI-IV-2A/processed_data')
 os.makedirs(processed_data_path, exist_ok=True)
 
 # Sampling rate and time split range

--- a/preprocessing/SHU/data_process.py
+++ b/preprocessing/SHU/data_process.py
@@ -63,9 +63,8 @@ for i in range(25):
             eeg_trial = data1[trial, :, :]
             eeg_trial = bandpass_filter(eeg_trial, lowcut=0.1, highcut=75.0, fs=250)
             eeg_trial = notch_filter(eeg_trial, freq=50.0, fs=250)
-            save_dir = processed_data_path + str(subject) + '/'
-            if not os.path.exists(save_dir):
-                os.makedirs(save_dir)
+            save_dir = os.path.join(processed_data_path, str(subject))
+            os.makedirs(save_dir, exist_ok=True)
             file_name = os.path.join(save_dir,  str(subject) + '_' + str(session) + '_' + str(trial+1) + '.pkl')
             with open(file_name, 'wb') as f:
                 pickle.dump({'X': eeg_trial, 'Y': label[trial]}, f)

--- a/preprocessing/SHU/multi_json_process.py
+++ b/preprocessing/SHU/multi_json_process.py
@@ -2,22 +2,18 @@ import json
 import os
 import pickle
 import numpy as np
-from collections import defaultdict
 import sys
 
 
-data_root = sys.argv[1]  
+data_root = sys.argv[1]
 print(f"Data root: {data_root}")
-processed_data_path = os.path.join(data_root,'SHU/processed_data')
+processed_data_path = os.path.join(data_root, 'SHU/processed_data')
 data_split_path = './preprocessing/SHU/multi_subject_json'
 os.makedirs(data_split_path, exist_ok=True)
 save_train_path = os.path.join(data_split_path, 'train.json')
 save_val_path = os.path.join(data_split_path, 'val.json')
 save_test_path = os.path.join(data_split_path, 'test.json')
 
-# path1 = './Preprocessing/SHU/processed_data/'
-# output_dir = './Preprocessing/SHU/multi_subject_json/'
-# os.makedirs(output_dir, exist_ok=True)
 
 def save_to_json(data, filename):
     with open(filename, 'w', encoding='utf-8') as f:
@@ -25,36 +21,31 @@ def save_to_json(data, filename):
     print(f"File has been saved to {filename}")
 
 
-def calculate_dataset_stats(data_list):
-    max_value = -float('inf')
-    min_value = float('inf')
-    channel_means = 0
-    channel_stds = 0
-    i = 0
+stats_map = {}
+
+
+def compute_stats_from_map(data_list):
+    max_value = -np.inf
+    min_value = np.inf
+    channel_means = np.zeros(32)
+    channel_stds = np.zeros(32)
+    count = 0
 
     for file_data in data_list:
-        file_path = file_data['file']
-        if not os.path.exists(file_path):
-            print(f"File does not exist: {file_path}")
+        stats = stats_map.get(file_data['file'])
+        if stats is None:
             continue
+        channel_means += stats['mean']
+        channel_stds += stats['std']
+        max_value = max(max_value, stats['max'])
+        min_value = min(min_value, stats['min'])
+        count += 1
 
-        with open(file_path, 'rb') as f:
-            data = pickle.load(f)
-        X = data['X']
+    if count == 0:
+        return max_value, min_value, channel_means, channel_stds
 
-        current_max = np.max(X)
-        current_min = np.min(X)
-        if current_max > max_value:
-            max_value = current_max
-        if current_min < min_value:
-            min_value = current_min
-
-        channel_means += np.mean(X, axis=-1)
-        channel_stds += np.std(X, axis=-1)
-        i += 1
-
-    mean_values = channel_means / i
-    std_values = channel_stds / i
+    mean_values = channel_means / count
+    std_values = channel_stds / count
 
     return max_value, min_value, mean_values, std_values
 
@@ -71,13 +62,12 @@ dataset_info_template = {
     "std": None
 }
 
-
 # Split by session
 train_data = []
 val_data = []
 test_data = []
 
-for i in range(1,26):
+for i in range(1, 26):
     subject_id = i
     subject_path = str(subject_id) + '/'
     data_folder = os.path.join(processed_data_path, subject_path)
@@ -98,6 +88,14 @@ for i in range(1,26):
                 try:
                     with open(file_path, 'rb') as f:
                         data = pickle.load(f)
+
+                    X = data['X']
+                    stats_map[file_path] = {
+                        'mean': np.mean(X, axis=-1),
+                        'std': np.std(X, axis=-1),
+                        'min': np.min(X),
+                        'max': np.max(X)
+                    }
 
                     label = data['Y'].tolist()
                     file_data = {
@@ -120,12 +118,12 @@ for i in range(1,26):
 print(f"train_set: {len(train_data)}, val_set: {len(val_data)}, test_set: {len(test_data)}")
 
 # Compute normalization parameters
-train_max, train_min, train_mean, train_std = calculate_dataset_stats(train_data)
+train_max, train_min, train_mean, train_std = compute_stats_from_map(train_data)
 
 dataset_info = dataset_info_template.copy()
 dataset_info.update({
-    "min": train_max,
-    "max": train_min,
+    "min": train_min,
+    "max": train_max,
     "mean": train_mean.tolist(),
     "std": train_std.tolist()
 })

--- a/preprocessing/Siena/data_process.py
+++ b/preprocessing/Siena/data_process.py
@@ -171,9 +171,12 @@ def process_edf(edf_path, seizure_records, processed_data_path, sampling_rate=51
 
         # Save all data segments
         base_name = os.path.splitext(current_file)[0]
+        patient_id = base_name.split('-')[0]
+        patient_dir = os.path.join(processed_data_path, patient_id)
+        os.makedirs(patient_dir, exist_ok=True)
         for idx, (seg, label) in enumerate(segments):
             output_data = {"X": seg, "Y": label}
-            output_file = os.path.join(processed_data_path, f"{base_name}_{idx}.pkl")
+            output_file = os.path.join(patient_dir, f"{base_name}_{idx}.pkl")
             with open(output_file, "wb") as f:
                 pickle.dump(output_data, f)
 

--- a/preprocessing/TUEV/cross_json_process.py
+++ b/preprocessing/TUEV/cross_json_process.py
@@ -1,14 +1,13 @@
 import json
 import os
-import random
 import pickle
 import numpy as np
 from natsort import natsorted
 import sys
 
-data_root = sys.argv[1]  
+data_root = sys.argv[1]
 print(f"Data root: {data_root}")
-processed_data_path = os.path.join(data_root,'TUEV/processed_data/')
+processed_data_path = os.path.join(data_root, 'TUEV/processed_data/')
 data_split_path = './preprocessing/TUEV/cross_subject_json'
 os.makedirs(data_split_path, exist_ok=True)
 train_folder = os.path.join(processed_data_path, "train")
@@ -18,35 +17,36 @@ save_train_path = os.path.join(data_split_path, 'train.json')
 save_val_path = os.path.join(data_split_path, 'val.json')
 save_test_path = os.path.join(data_split_path, 'test.json')
 
-# base_folder = ".Preprocessing/TUEV/processed_data/final_data"
-# train_folder = os.path.join(base_folder, "train")
-# val_folder = os.path.join(base_folder, "eval")
-# eval_folder = os.path.join(base_folder, "test")
-# cross_subject_json_folder = ".Preprocessing/TUEV/cross_subject_json"
-# os.makedirs(os.path.dirname(cross_subject_json_folder), exist_ok=True)
-
-# save_folder_test = os.path.join(cross_subject_split_folder, 'test.json')
-# save_folder_train = os.path.join(cross_subject_split_folder, 'train.json')
-# save_folder_val = os.path.join(cross_subject_split_folder, 'val.json')
-
-
 sampling_rate = 250
 ch_names = ['FP1', 'FP2', 'F3', 'F4', 'C3', 'C4', 'P3', 'P4', 'O1', 'O2', 'F7', 'F8', 'T3', 'T4', 'T5', 'T6', 'A1', 'A2', 'FZ', 'CZ', 'PZ', 'T1', 'T2']
 num_channels = len(ch_names)
+
 total_mean = np.zeros(num_channels)
 total_std = np.zeros(num_channels)
 num_all = 0
-max_value = -1
-min_value = 1e6
+max_value = -np.inf
+min_value = np.inf
 
-def is_23_channels(pkl_file):
+
+def get_subject_name(file_path):
+    base = os.path.basename(file_path)
+    if "_" in base:
+        return base.split("_")[0]
+    return base[:8]
+
+
+def load_eeg(file_path):
     try:
-        eeg_data = pickle.load(open(pkl_file, "rb"))
+        with open(file_path, "rb") as f:
+            eeg_data = pickle.load(f)
         eeg = eeg_data['X']
-        return eeg.shape[0] == 23
+        if eeg.shape[0] != num_channels:
+            return None
+        return eeg_data
     except Exception as e:
-        print(f"Error loading file {pkl_file}: {e}")
-        return False
+        print(f"Error loading file {file_path}: {e}")
+        return None
+
 
 train_files = natsorted([os.path.join(train_folder, f) for f in os.listdir(train_folder) if f.endswith('.pkl')])
 tuples_list_train = []
@@ -54,39 +54,36 @@ subject_id_counter = 0
 subject_id_map = {}
 
 for file in train_files:
-    if not is_23_channels(file):
+    eeg_data = load_eeg(file)
+    if eeg_data is None:
         continue
-    try:
-        eeg_data = pickle.load(open(file, "rb"))
-        label = eeg_data['Y']
-        eeg = eeg_data['X']
-        subject_folder = os.path.basename(file)[:8]
-        if subject_folder not in subject_id_map:
-            subject_id_map[subject_folder] = subject_id_counter
-            subject_id_counter += 1
-        # Calculate normalization parameters.
-        for j in range(num_channels):
-            total_mean[j] += eeg[j].mean()
-            total_std[j] += eeg[j].std()
-        num_all += 1
-        per_max_value = max(eeg.reshape(-1))
-        per_min_value = min(eeg.reshape(-1))
-        if per_max_value > max_value:
-            max_value = per_max_value
-        if per_min_value < min_value:
-            min_value = per_min_value
-        data = {
-            "subject_id": subject_id_map[subject_folder],
-            "subject_name": subject_folder,
-            "file": file,
-            "label": label
-        }
-        tuples_list_train.append(data)
-    except Exception as e:
-        print(f"Error loading file {file}: {e}")
+    label = eeg_data['Y']
+    eeg = eeg_data['X']
+    subject_name = get_subject_name(file)
+    if subject_name not in subject_id_map:
+        subject_id_map[subject_name] = subject_id_counter
+        subject_id_counter += 1
 
-data_mean = (total_mean / num_all).tolist()
-data_std = (total_std / num_all).tolist()
+    total_mean += eeg.mean(axis=1)
+    total_std += eeg.std(axis=1)
+    num_all += 1
+    max_value = max(max_value, eeg.max())
+    min_value = min(min_value, eeg.min())
+
+    data = {
+        "subject_id": subject_id_map[subject_name],
+        "subject_name": subject_name,
+        "file": file,
+        "label": label
+    }
+    tuples_list_train.append(data)
+
+if num_all == 0:
+    data_mean = total_mean.tolist()
+    data_std = total_std.tolist()
+else:
+    data_mean = (total_mean / num_all).tolist()
+    data_std = (total_std / num_all).tolist()
 
 train_dataset = {
     "subject_data": tuples_list_train,
@@ -99,33 +96,28 @@ train_dataset = {
         "std": data_std
     }
 }
-formatted_json_train = json.dumps(train_dataset, indent=2)
 with open(save_train_path, 'w') as f:
-    f.write(formatted_json_train)
+    json.dump(train_dataset, f, indent=2)
 
 val_files = natsorted([os.path.join(val_folder, f) for f in os.listdir(val_folder) if f.endswith('.pkl')])
 tuples_list_val = []
 
 for file in val_files:
-    if not is_23_channels(file):
+    eeg_data = load_eeg(file)
+    if eeg_data is None:
         continue
-    try:
-        eeg_data = pickle.load(open(file, "rb"))
-        label = eeg_data['Y']
-        eeg = eeg_data['X']
-        subject_folder = os.path.basename(file)[:8]
-        if subject_folder not in subject_id_map:
-            subject_id_map[subject_folder] = subject_id_counter
-            subject_id_counter += 1
-        data = {
-            "subject_id": subject_id_map[subject_folder],
-            "subject_name": subject_folder,
-            "file": file,
-            "label": label
-        }
-        tuples_list_val.append(data)
-    except Exception as e:
-        print(f"Error loading file {file}: {e}")
+    label = eeg_data['Y']
+    subject_name = get_subject_name(file)
+    if subject_name not in subject_id_map:
+        subject_id_map[subject_name] = subject_id_counter
+        subject_id_counter += 1
+    data = {
+        "subject_id": subject_id_map[subject_name],
+        "subject_name": subject_name,
+        "file": file,
+        "label": label
+    }
+    tuples_list_val.append(data)
 
 val_dataset = {
     "subject_data": tuples_list_val,
@@ -138,29 +130,27 @@ val_dataset = {
         "std": data_std
     }
 }
-formatted_json_val = json.dumps(val_dataset, indent=2)
 with open(save_val_path, 'w') as f:
-    f.write(formatted_json_val)
+    json.dump(val_dataset, f, indent=2)
 
 eval_files = natsorted([os.path.join(eval_folder, f) for f in os.listdir(eval_folder) if f.endswith('.pkl')])
 tuples_list_test = []
 error_list = []
 
 for file in eval_files:
-    if not is_23_channels(file):
+    eeg_data = load_eeg(file)
+    if eeg_data is None:
         continue
     try:
-        data_name = os.path.basename(file).split('_')[1][:3]
-        if data_name not in subject_id_map:
-            subject_id_map[data_name] = subject_id_counter
-            subject_id_counter += 1
-        subject_id = subject_id_map[data_name]
-        eeg_data = pickle.load(open(file, "rb"))
         label = eeg_data['Y']
-        eeg = eeg_data['X']
+        subject_name = get_subject_name(file)
+        if subject_name not in subject_id_map:
+            subject_id_map[subject_name] = subject_id_counter
+            subject_id_counter += 1
+        subject_id = subject_id_map[subject_name]
         data = {
             "subject_id": subject_id,
-            "subject_name": data_name,
+            "subject_name": subject_name,
             "file": file,
             "label": label
         }
@@ -180,8 +170,7 @@ test_dataset = {
         "std": data_std
     }
 }
-formatted_json_test = json.dumps(test_dataset, indent=2)
 with open(save_test_path, 'w') as f:
-    f.write(formatted_json_test)
+    json.dump(test_dataset, f, indent=2)
 
 print("error list: ", error_list)

--- a/preprocessing/TUEV/data_process.py
+++ b/preprocessing/TUEV/data_process.py
@@ -15,13 +15,12 @@ print(f"Data root: {data_root}")
 raw_data_path = os.path.join(data_root,'TUEV/raw_data/v2.0.1')
 processed_data_path = os.path.join(data_root,'TUEV/processed_data')
 os.makedirs(processed_data_path, exist_ok=True)
-train_dir = os.path.join(processed_data_path, "train_dir")
-eval_dir = os.path.join(processed_data_path, "eval_dir")
-test_dir = os.path.join(processed_data_path, "test_dir")
-if not os.path.exists(train_dir):
-    os.makedirs(train_dir)
-if not os.path.exists(test_dir):
-    os.makedirs(test_dir)
+train_dir = os.path.join(processed_data_path, "train")
+eval_dir = os.path.join(processed_data_path, "eval")
+test_dir = os.path.join(processed_data_path, "test")
+os.makedirs(train_dir, exist_ok=True)
+os.makedirs(eval_dir, exist_ok=True)
+os.makedirs(test_dir, exist_ok=True)
 
   
 # final_data = os.path.join(processed_data_path, "final_data")

--- a/util/eegdatasets.py
+++ b/util/eegdatasets.py
@@ -41,7 +41,8 @@ class EEGDataset():
         test_root = f"{dataset_info['root']['multi']}/test.json"
 
         dataset_root = train_root if self.train else test_root
-        all_json_data = json.load(open(dataset_root, "r"))
+        with open(dataset_root, "r") as dataset_file:
+            all_json_data = json.load(dataset_file)
         data_info = all_json_data['dataset_info']
         self.default_rate = data_info['sampling_rate']
         self.ch_names = data_info['ch_names']
@@ -89,7 +90,8 @@ class EEGDataset():
             eeg_paths = [item["EEG"] for item in items]
             eeg_features = []
             for eeg_path in eeg_paths:
-                sample = pickle.load(open(eeg_path, "rb"))['X']
+                with open(eeg_path, "rb") as eeg_file:
+                    sample = pickle.load(eeg_file)['X']
                 if self.sampling_rate != self.default_rate:
                     sample = self.resample_data(sample)
                 sample = self.normalize(sample)
@@ -158,7 +160,8 @@ class EEGDataset():
         eeg_sources = self.files[index]
         if self.train:
             datapath = eeg_sources['EEG']
-            x = pickle.load(open(datapath, "rb"))['X']
+            with open(datapath, "rb") as eeg_file:
+                x = pickle.load(eeg_file)['X']
             if self.sampling_rate != self.default_rate:
                 x = self.resample_data(x)
             x = self.normalize(x)


### PR DESCRIPTION
- Fix BCI-IV-2A preprocessing path naming to match dataset conventions.
- Standardize Siena output into per‑patient folders and update split stats to single‑pass reads. 
- Align TUEV processed dirs (train/eval/test) and subject parsing across splits. 
- Correct SHU split stats (min/max inversion) and compute stats without double reads. 
- Use context‑managed file I/O in retrieval dataset loader.